### PR TITLE
fix: safari bike icon width

### DIFF
--- a/src/components/map/icon.tsx
+++ b/src/components/map/icon.tsx
@@ -1,10 +1,6 @@
 import styled from 'styled-components';
 
 export const StyledBikeIcon = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-
   .active & svg,
   & svg:hover,
   & svg:focus {
@@ -16,6 +12,7 @@ export const StyledBikeIcon = styled.div`
   }
 
   & svg {
+    width: 100%;
     border-radius: 50%;
     border: 2px solid #4b0082;
     background-color: white;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ const Home: NextPage = () => {
           </Col>
           <Col mobileS={8} desktop={4} className="mx-auto">
             <p>
-              A demo web app allowing to explore city bike stations and rides associated with them.
+              This is a demo web app. It lists city bike stations and the rides associated with them.
               The data belongs to City Bike Finland and covers over 400 stations and 1.5 million
               rides from May to July 2021.
             </p>


### PR DESCRIPTION
icon not properly rendered on safari